### PR TITLE
Fix equations in MicroCHP section

### DIFF
--- a/doc/src/docs/InputOutputReference/01d-InputOutputReference.md
+++ b/doc/src/docs/InputOutputReference/01d-InputOutputReference.md
@@ -21604,7 +21604,7 @@ This is the temperature of exhaust leaving the generator.   This output is avail
 
 ### Generator:MicroCHP
 
-This object is used to model small-scale combined heat and power (micro CHP) electric generators using the model developed by IEA/ECBCS Annex 42     see http://www.ecbcs.org/annexes/annex42.htm.     The model was developed for both internal combustion and Stirling cycle engines, but might be used for other types of residential CHP devices.
+This object is used to model small-scale combined heat and power (micro CHP) electric generators using the model developed by IEA/ECBCS [Annex 42](http://www.ecbcs.org/annexes/annex42.htm). The model was developed for both internal combustion and Stirling cycle engines, but might be used for other types of residential CHP devices.
 
 Note that unlike other component models in EnergyPlus, this model is not normalized. Therefore, performance coefficients developed for one type and capacity of CHP device cannot be used for a device with a different capacity.
 
@@ -21687,19 +21687,19 @@ This is the maximum temperature of cooling water inlet or outlet that can occur 
 
 #### Field: Electrical Efficiency Curve Name
 
-This is the name of Curve:Triquadratic object that defines the steady-state net electrical efficiency.   The electrical efficiency, <span>\({\eta_e}\)</span>, is a function of   the cooling water mass flow rate, <span>\({\dot m_{cw}}\)</span>, the temperature of the cooling water at the inlet, <span>\({T_{cw}}\)</span>, the steady-state net electrical power produced, <span>\({P_{net,ss}}\)</span>.
+This is the name of Curve:Triquadratic object that defines the steady-state net electrical efficiency.   The electrical efficiency, <span>$ \eta_e $</span>, is a function of the cooling water mass flow rate <span> $ \dot m_{cw}  $</span>, the temperature of the cooling water at the inlet, <span>$ T_{cw} $</span>, the steady-state net electrical power produced, <span>$ P_{net,ss} $</span>.
 
-<span>\({\eta_e} = f\left( {{P_{net,ss}},{{\dot m}_{cw}},{T_{cw}}} \right)\)</span>
+<div> \[ \eta_e = f\left( {{P_{net,ss}},{{\dot m}_{cw}},{T_{cw}}} \right) \] </div>
 
-The associated Curve:Triquadratic object should be defined with the independent variables <span>\({P_{net,ss}},{\dot m_{cw}},{T_{cw}}\)</span>  corresponding to *x*, *y*, and *z*, respectively.
+The associated Curve:Triquadratic object should be defined with the independent variables <span> $ {P_{net,ss}},{\dot m_{cw}},{T_{cw}} $ </span>  corresponding to *x*, *y*, and *z*, respectively.
 
 #### Field: Thermal Efficiency Curve Name
 
-This is the name of a Curve:Triquadratic object that defines the steady-state net thermal efficiency.   The thermal efficiency, <span>\({\eta_q}\)</span>, is a function of   the cooling water mass flow rate, <span>\({\dot m_{cw}}\)</span>, the temperature of the cooling water at the inlet, <span>\({T_{cw}}\)</span>, the steady-state net electrical power produced, <span>\({P_{net,ss}}\)</span>.
+This is the name of a Curve:Triquadratic object that defines the steady-state net thermal efficiency.   The thermal efficiency, <span>$ \eta_q $</span>, is a function of the cooling water mass flow rate, <span>$ \dot m_{cw} $</span>, the temperature of the cooling water at the inlet, <span>$ T_{cw} $</span>, the steady-state net electrical power produced, <span> $ P_{net,ss} $ </span>.
 
-<span>\({\eta_q} = f\left( {{P_{net,ss}},{{\dot m}_{cw}},{T_{cw}}} \right)\)</span>
+<div> \[ {\eta_q} = f\left( {{P_{net,ss}},{{\dot m}_{cw}},{T_{cw}}} \right) \] </div>
 
-The associated Curve:Triquadratic object should be defined with the independent variables <span>\({P_{net,ss}},{\dot m_{cw}},{T_{cw}}\)</span>  corresponding to *x*, *y*, and *z*, respectively.
+The associated Curve:Triquadratic object should be defined with the independent variables <span> $ {P_{net,ss}},{\dot m_{cw}},{T_{cw}} $ </span>  corresponding to *x*, *y*, and *z*, respectively.
 
 #### Field: Cooling Water Flow Rate Mode
 
@@ -21709,7 +21709,7 @@ For internal control, the following field is used to define a Biquadratic curve 
 
 #### Field: Cooling Water Flow Rate Curve Name
 
-This field contains the name of a Curve:Biquadratic object that defines the mass flow rate of cooling water, <span>\({\dot m_{cw}}\)</span>.   This field is only used if the prior field is set to    InternalControl.      The mass flow of cooling water is a function of steady-state power, <span>\({P_{net,ss}}\)</span>, and the inlet temperature of the cooling water, <span>\({T_{cw}}\)</span>.   The associated Curve:Biquadratic should be defined with the independent variables <span>\({P_{net,ss}}\)</span>  and <span>\({T_{cw}}\)</span>  corresponding to *x* and *y*, respectively.
+This field contains the name of a Curve:Biquadratic object that defines the mass flow rate of cooling water, <span> $ {\dot m_{cw}} $ </span>.   This field is only used if the prior field is set to InternalControl. The mass flow of cooling water is a function of steady-state power, <span> $ {P_{net,ss}} $ </span>, and the inlet temperature of the cooling water, <span> $ {T_{cw}} $ </span>.   The associated Curve:Biquadratic should be defined with the independent variables <span> $ {P_{net,ss}} $ </span> and <span> $ {T_{cw}} $ </span> corresponding to *x* and *y*, respectively.
 
 #### Field: Air Flow Rate Curve Name
 
@@ -21793,33 +21793,33 @@ An example IDF showing how this object is used is provided below:
 
 ```idf
    Generator:MicroCHP:NonNormalizedParameters,
-       SENERTECH5_5KW,                   !- Name
-       5500.0000,                             !- Maximum Electric Power {W}
-       0.0000,                                   !- Minimum Electric Power {W}
-       0.0000,                                   !- Minimum Cooling Water Flow Rate {kg/s}
-       80.0000,                                 !- Maximum Cooling Water Temperature {C}
-       SenerTechElEff,                   !- Electrical Efficiency Curve Name
-       SenerTechThermEff,             !- Thermal Efficiency Curve Name
-       InternalControl,                 !- Cooling Water Flow Rate Mode
-       SenerTechCoolWaterflow,   !- Cooling Water Flow Rate Curve Name
-       SenerTechAirFlow,               !- Air Flow Rate Curve Name
-       1000000000.0000,                 !- Maximum Net Electrical Power Rate of Change {W/s}
-       1000000000.0000,                 !- Maximum Fuel Flow Rate of Change {kg/s2}
-       741.0000,                               !- Heat Exchanger U-Factor Times Area Value {W/K}
-       13.7000,                                 !- Skin Loss U-Factor Times Area Value {W/K}
-       0.5000,                                   !- Skin Loss Radiative Fraction
-       63605.6000,                           !- Aggregated Thermal Mass of Energy Conversion Portion of Generator {W/K}
-       1000.7000,                             !- Aggregated Thermal Mass of Heat Recovery Portion of Generator {W/K}
-       0.0000,                                   !- Standby Power {W}
-       TimeDelay,                             !- Warm Up Mode
-       ,                                               !- Warm Up Fuel Flow Rate Coefficient
-       ,                                               !- Nominal Engine Operating Temperature {C}
-       ,                                               !- Warm Up Power Coefficient
-       ,                                               !- Warm Up Fuel Flow Rate Limit Ratio
-       60.0000,                                 !- Warm Up Delay Time {s}
-       0.0000,                                   !- Cool Down Power {W}
-       60.0000,                                 !- Cool Down Delay Time {s}
-       OptionalCoolDown;               !- Restart Mode
+       SENERTECH5_5KW,         !- Name
+       5500.0000,              !- Maximum Electric Power {W}
+       0.0000,                 !- Minimum Electric Power {W}
+       0.0000,                 !- Minimum Cooling Water Flow Rate {kg/s}
+       80.0000,                !- Maximum Cooling Water Temperature {C}
+       SenerTechElEff,         !- Electrical Efficiency Curve Name
+       SenerTechThermEff,      !- Thermal Efficiency Curve Name
+       InternalControl,        !- Cooling Water Flow Rate Mode
+       SenerTechCoolWaterflow, !- Cooling Water Flow Rate Curve Name
+       SenerTechAirFlow,       !- Air Flow Rate Curve Name
+       1000000000.0000,        !- Maximum Net Electrical Power Rate of Change {W/s}
+       1000000000.0000,        !- Maximum Fuel Flow Rate of Change {kg/s2}
+       741.0000,               !- Heat Exchanger U-Factor Times Area Value {W/K}
+       13.7000,                !- Skin Loss U-Factor Times Area Value {W/K}
+       0.5000,                 !- Skin Loss Radiative Fraction
+       63605.6000,             !- Aggregated Thermal Mass of Energy Conversion Portion of Generator {W/K}
+       1000.7000,              !- Aggregated Thermal Mass of Heat Recovery Portion of Generator {W/K}
+       0.0000,                 !- Standby Power {W}
+       TimeDelay,              !- Warm Up Mode
+       ,                       !- Warm Up Fuel Flow Rate Coefficient
+       ,                       !- Nominal Engine Operating Temperature {C}
+       ,                       !- Warm Up Power Coefficient
+       ,                       !- Warm Up Fuel Flow Rate Limit Ratio
+       60.0000,                !- Warm Up Delay Time {s}
+       0.0000,                 !- Cool Down Power {W}
+       60.0000,                !- Cool Down Delay Time {s}
+       OptionalCoolDown;       !- Restart Mode
 ```
 
 ### Generator:MicroCHP Outputs


### PR DESCRIPTION
The equations are super finicky with the Markdown/HTML/TeX solution we currently have.  I played around with them (building the html with mkdocs each attempt) until they all looked good.  I also made a couple other minor changes.  Please pull this PR into your repo, which will then update it in the NREL/EnergyPlus PR and I can merge it in over there.
